### PR TITLE
added AST printing

### DIFF
--- a/src/frontend/ast/ast_struct.rs
+++ b/src/frontend/ast/ast_struct.rs
@@ -124,12 +124,12 @@ impl AST {
 }
 
 /// Formats an AST
-fn ast_format(root: &ASTNode, string: &mut String, depth: usize) {
-    let rep: String = std::iter::repeat("\t").take(depth).collect::<String>() + &root.get_element().to_string() + "\n";
-    string.push_str(&rep);
+fn ast_format(root: &ASTNode, output_string_ref: &mut String, depth: usize) {
+    let node_repr_with_depth: String = std::iter::repeat("\t").take(depth).collect::<String>() + &root.get_element().to_string() + "\n";
+    output_string_ref.push_str(&node_repr_with_depth);
 
     for child in root.get_children().iter() {
-        ast_format(child, string, depth + 1)
+        ast_format(child, output_string_ref, depth + 1)
     }
 
 }

--- a/src/frontend/ast/ast_struct.rs
+++ b/src/frontend/ast/ast_struct.rs
@@ -123,6 +123,27 @@ impl AST {
 
 }
 
+/// Formats an AST
+fn ast_format(root: &ASTNode, string: &mut String, depth: usize) {
+    let rep: String = std::iter::repeat("\t").take(depth).collect::<String>() + &root.get_element().to_string() + "\n";
+    string.push_str(&rep);
+
+    for child in root.get_children().iter() {
+        ast_format(child, string, depth + 1)
+    }
+
+}
+
+impl fmt::Display for AST {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut output_str = String::from("AST: \n");
+
+        ast_format(&self.get_root(), &mut output_str, 0);
+
+        write!(f, "{}", output_str)
+    }
+}
+
 impl ASTNode {
     /// Creates a new ast node
     pub fn new(element: SyntaxElement) -> Self {

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -493,3 +493,33 @@ fn test_match_statement_parsing() {
 
     assert_eq!(ast, expected_ast);
 }
+
+#[test]
+fn test_ast_print() {
+    let tokens = vec![
+        Token::MATCH,
+        Token::IDENTIFIER(vec!['x']),
+        Token::LBRACKET,
+        Token::RBRACKET,
+        Token::EOF,
+    ];
+    let ast: AST = Parser::parse(tokens).expect("Failed to parse");
+    println!("Printing parsed AST:");
+    println!("{}", ast);
+    println!("Printing parsed AST again:");
+    println!("{}", ast);
+
+    let mut match_statement_node: ASTNode = ASTNode::new(SyntaxElement::MatchStatement);
+    let variable_node: ASTNode = ASTNode::new(SyntaxElement::Identifier("x".to_string()));
+    let arms_node: ASTNode = ASTNode::new(SyntaxElement::BlockExpression); 
+
+    match_statement_node.add_child(variable_node);
+    match_statement_node.add_child(arms_node);
+
+    let mut top_level_expr: ASTNode = ASTNode::new(SyntaxElement::TopLevelExpression);
+    top_level_expr.add_child(match_statement_node);
+
+    let expected_ast: AST = AST::new(top_level_expr);
+    println!("Printing expected AST:");
+    println!("{}", expected_ast);
+}

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -494,33 +494,3 @@ fn test_match_statement_parsing() {
     assert_eq!(ast, expected_ast);
 }
 
-#[test]
-fn test_ast_print() {
-    let tokens = vec![
-        Token::MATCH,
-        Token::IDENTIFIER(vec!['x']),
-        Token::LBRACKET,
-        Token::RBRACKET,
-        Token::EOF,
-    ];
-    let ast: AST = Parser::parse(tokens).expect("Failed to parse");
-    println!("Printing parsed AST:");
-    println!("{}", ast);
-    println!("Printing parsed AST again:");
-    println!("{}", ast);
-
-    let mut match_statement_node: ASTNode = ASTNode::new(SyntaxElement::MatchStatement);
-    let variable_node: ASTNode = ASTNode::new(SyntaxElement::Identifier("x".to_string()));
-    let arms_node: ASTNode = ASTNode::new(SyntaxElement::BlockExpression); 
-
-    match_statement_node.add_child(variable_node);
-    match_statement_node.add_child(arms_node);
-
-    let mut top_level_expr: ASTNode = ASTNode::new(SyntaxElement::TopLevelExpression);
-    top_level_expr.add_child(match_statement_node);
-
-    let expected_ast: AST = AST::new(top_level_expr);
-    println!("Printing expected AST:");
-    println!("{}", expected_ast);
-    assert_eq!(ast.to_string(),"AST: \nTopLevelExpression\n\tMatchStatement\n\t\tIdentifier(x)\n\t\tBlockExpression\n")
-}

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -522,4 +522,5 @@ fn test_ast_print() {
     let expected_ast: AST = AST::new(top_level_expr);
     println!("Printing expected AST:");
     println!("{}", expected_ast);
+    assert_eq!(ast.to_string(),"AST: \nTopLevelExpression\n\tMatchStatement\n\t\tIdentifier(x)\n\t\tBlockExpression\n")
 }

--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -1,10 +1,11 @@
 use compiler_core::frontend::{
     ast::{
-        ast_struct::*,
-        syntax_element::*,
+        ast_struct::AST,
+        ast_struct::ASTNode,
+        syntax_element::SyntaxElement,
     },
-    lexer::token::*,
-    parser::parser_core::*,
+    lexer::token::Token,
+    parser::parser_core::Parser,
 };
 
 #[test]

--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -1,0 +1,39 @@
+use compiler_core::frontend::{
+    ast::{
+        ast_struct::*,
+        syntax_element::*,
+    },
+    lexer::token::*,
+    parser::parser_core::*,
+};
+
+#[test]
+fn test_ast_print() {
+    let tokens = vec![
+        Token::MATCH,
+        Token::IDENTIFIER(vec!['x']),
+        Token::LBRACKET,
+        Token::RBRACKET,
+        Token::EOF,
+    ];
+    let ast: AST = Parser::parse(tokens).expect("Failed to parse");
+    println!("Printing parsed AST:");
+    println!("{}", ast);
+    println!("Printing parsed AST again:");
+    println!("{}", ast);
+
+    let mut match_statement_node: ASTNode = ASTNode::new(SyntaxElement::MatchStatement);
+    let variable_node: ASTNode = ASTNode::new(SyntaxElement::Identifier("x".to_string()));
+    let arms_node: ASTNode = ASTNode::new(SyntaxElement::BlockExpression); 
+
+    match_statement_node.add_child(variable_node);
+    match_statement_node.add_child(arms_node);
+
+    let mut top_level_expr: ASTNode = ASTNode::new(SyntaxElement::TopLevelExpression);
+    top_level_expr.add_child(match_statement_node);
+
+    let expected_ast: AST = AST::new(top_level_expr);
+    println!("Printing expected AST:");
+    println!("{}", expected_ast);
+    assert_eq!(ast.to_string(),"AST: \nTopLevelExpression\n\tMatchStatement\n\t\tIdentifier(x)\n\t\tBlockExpression\n")
+}


### PR DESCRIPTION
Implementation of AST printing, closes #48 

output of test:
Printing parsed AST:
AST: 
TopLevelExpression
        MatchStatement
                Identifier(x)
                BlockExpression

Printing parsed AST again:
AST: 
TopLevelExpression
        MatchStatement
                Identifier(x)
                BlockExpression

Printing expected AST:
AST: 
TopLevelExpression
        MatchStatement
                Identifier(x)
                BlockExpression

test test_ast_print ... ok